### PR TITLE
fix: Fail release workflow if publishing fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,23 +58,21 @@ jobs:
         run: pnpm exec vsce ls
 
       - name: Publish to VS Code Marketplace
-        continue-on-error: true
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
-          if [ -n "$VSCE_PAT" ]; then
-            pnpm exec vsce publish
-          else
-            echo "VSCE_PAT not set, skipping marketplace publish"
+          if [ -z "$VSCE_PAT" ]; then
+            echo "::error::VSCE_PAT secret is not set"
+            exit 1
           fi
+          pnpm exec vsce publish
 
       - name: Publish to Open VSX Registry
-        continue-on-error: true
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
-          if [ -n "$OVSX_PAT" ]; then
-            pnpm exec ovsx publish beadsx-*.vsix -p "$OVSX_PAT"
-          else
-            echo "OVSX_PAT not set, skipping Open VSX publish"
+          if [ -z "$OVSX_PAT" ]; then
+            echo "::error::OVSX_PAT secret is not set"
+            exit 1
           fi
+          pnpm exec ovsx publish beadsx-*.vsix -p "$OVSX_PAT"


### PR DESCRIPTION
## Summary

- Make release workflow fail explicitly when publishing to VS Code Marketplace or Open VSX Registry fails
- Add checks for missing VSCE_PAT and OVSX_PAT secrets with clear error messages
- Publishing commands will now fail the workflow if they encounter errors

## Changes

- Remove silent failure behavior from publish steps
- Add explicit secret validation before running publish commands
- Use `exit 1` on missing secrets to fail fast with descriptive error

🤖 Generated with [Claude Code](https://claude.com/claude-code)