### PR TITLE
fix: Install platform-specific OpenTUI packages for cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
 
+      - name: Install platform-specific OpenTUI packages
+        run: |
+          # Install platform-specific native bindings for cross-compilation
+          pnpm add -D @opentui/core-darwin-arm64 @opentui/core-darwin-x64 @opentui/core-linux-x64 @opentui/core-linux-arm64 @opentui/core-win32-x64
+
       - name: Build CLI binaries
         run: |
           mkdir -p dist


### PR DESCRIPTION
## Summary
Fixes the release workflow failure when building CLI binaries for cross-compilation.

## Problem
The `@opentui/core` package uses dynamic platform-specific imports that Bun's bundler cannot resolve at compile time:
```
error: Could not resolve: "@opentui/core-darwin-arm64/index.ts"
```

## Solution
Install all platform-specific native binding packages before building:
- `@opentui/core-darwin-arm64`
- `@opentui/core-darwin-x64`
- `@opentui/core-linux-x64`
- `@opentui/core-linux-arm64`
- `@opentui/core-win32-x64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)