### PR TITLE
fix: Release workflow fixes for vsce verification and version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,17 @@ jobs:
           bun build --compile src/cli/index.tsx --outfile dist/bdx-linux-arm64 --target bun-linux-arm64
           bun build --compile src/cli/index.tsx --outfile dist/bdx-windows-x64.exe --target bun-windows-x64
 
+      - name: Restore clean dependencies
+        run: |
+          # Remove platform-specific packages that break vsce verification
+          rm -rf node_modules
+          pnpm install
+
+      - name: Update package version from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          npm pkg set version=$VERSION
+
       - name: Package extension
         run: pnpm run package
 


### PR DESCRIPTION
## Summary
- Add step to restore clean dependencies after CLI build (removes platform-specific OpenTUI packages that break vsce verification)
- Add step to update package.json version from git tag to ensure vsix filename matches release version

## Background
The v0.2.14 release had two issues:
1. **vsce verification failed**: Platform-specific OpenTUI packages installed for cross-compilation broke `vsce ls` (npm dependency verification)
2. **Version mismatch**: The vsix was named `beadsx-0.2.12.vsix` despite being tagged `v0.2.14` because package.json wasn't updated

## Test plan
- [ ] Create a new release tag (e.g., v0.2.15)
- [ ] Verify all workflow steps pass including "Verify package"
- [ ] Verify vsix filename matches the tag version

🤖 Generated with [Claude Code](https://claude.com/claude-code)