### PR TITLE
fix: Ensure macOS binaries are executable before zipping

### DIFF
--- a/scripts/sign-macos.mjs
+++ b/scripts/sign-macos.mjs
@@ -119,6 +119,9 @@ async function createZip(binaryPath) {
     unlinkSync(zipPath);
   }
 
+  // Ensure binary is executable (may be lost during cross-platform transfer)
+  await run(`chmod +x "${binaryPath}"`);
+
   console.log(`Creating ZIP: ${basename(zipPath)}`);
   await run(`cd "${dir}" && zip -j "${basename(zipPath)}" "${binaryName}"`);
 


### PR DESCRIPTION
## Summary
- Add `chmod +x` before creating ZIP to preserve executable permissions
- Fixes issue where downloaded macOS binaries require manual `chmod +x` after extraction

## Test plan
- [x] Local build and sign works
- [ ] CI workflow produces executable binaries in ZIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)