### PR TITLE
Reorder conductor setup to copy .env before pnpm install

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "setup": "pnpm i; cp ~/git/raychaser/experimental/beadsx/.git/beads-worktrees/main/.env .",
+        "setup": "cp ~/git/raychaser/experimental/beadsx/.git/beads-worktrees/main/.env . && pnpm i",
         "run": "pnpm cli:dev"
     }
 }


### PR DESCRIPTION
Ensures .env file is available when dependencies are installed.

This fixes the setup process by copying the .env file before running pnpm, so that environment variables are available during the installation phase.