### PR TITLE
feat: render markdown in detail view descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
   },
   "dependencies": {
     "commander": "^14.0.2",
+    "marked": "^17.0.4",
     "yaml": "^2.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       commander:
         specifier: ^14.0.2
         version: 14.0.2
+      marked:
+        specifier: ^17.0.4
+        version: 17.0.4
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
@@ -162,24 +165,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.11':
     resolution: {integrity: sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.11':
     resolution: {integrity: sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.11':
     resolution: {integrity: sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.11':
     resolution: {integrity: sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw==}
@@ -699,24 +706,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/crc32-linux-arm64-musl@1.10.6':
     resolution: {integrity: sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/crc32-linux-x64-gnu@1.10.6':
     resolution: {integrity: sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/crc32-linux-x64-musl@1.10.6':
     resolution: {integrity: sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/crc32-wasm32-wasi@1.10.6':
     resolution: {integrity: sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==}
@@ -850,56 +861,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -2003,6 +2025,11 @@ packages:
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
+  marked@17.0.4:
+    resolution: {integrity: sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -4861,6 +4888,8 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  marked@17.0.4: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,36 @@ const escapeHtml = (str: string) =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
 
+// Markdown renderer for detail view descriptions
+// Uses lazy initialization to avoid ESM/CJS import issues at module load time.
+// esbuild bundles the ESM 'marked' package into CJS at build time.
+let markedInstance: { parse(src: string): string | Promise<string> } | null = null;
+
+function getMarked(): typeof markedInstance {
+  if (!markedInstance) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Marked } = require('marked') as { Marked: new (opts: object) => typeof markedInstance };
+      markedInstance = new Marked({ breaks: true, gfm: true });
+    } catch {
+      return null;
+    }
+  }
+  return markedInstance;
+}
+
+function renderMarkdown(text: string): string {
+  const md = getMarked();
+  if (!md) return escapeHtml(text);
+  try {
+    const result = md.parse(text);
+    if (typeof result === 'string') return result;
+    return escapeHtml(text);
+  } catch {
+    return escapeHtml(text);
+  }
+}
+
 // Date formatting for detail view (module-level to avoid recreation per call)
 const formatDetailDate = (dateStr: string) => {
   try {
@@ -222,6 +252,79 @@ function getDetailHtml(issue: BeadsIssue, ancestors: BeadsIssue[], children: Bea
       font-family: var(--vscode-editor-font-family);
       font-size: var(--vscode-editor-font-size);
     }
+    .section-content.markdown-body {
+      white-space: normal;
+      font-family: var(--vscode-font-family);
+      line-height: 1.6;
+    }
+    .markdown-body h1, .markdown-body h2, .markdown-body h3,
+    .markdown-body h4, .markdown-body h5, .markdown-body h6 {
+      margin-top: 16px;
+      margin-bottom: 8px;
+      color: var(--vscode-foreground);
+    }
+    .markdown-body h1 { font-size: 1.4em; }
+    .markdown-body h2 { font-size: 1.2em; }
+    .markdown-body h3 { font-size: 1.1em; }
+    .markdown-body p {
+      margin: 8px 0;
+    }
+    .markdown-body ul, .markdown-body ol {
+      padding-left: 24px;
+      margin: 8px 0;
+    }
+    .markdown-body li {
+      margin: 4px 0;
+    }
+    .markdown-body code {
+      font-family: var(--vscode-editor-font-family);
+      font-size: var(--vscode-editor-font-size);
+      background-color: var(--vscode-textCodeBlock-background);
+      padding: 2px 5px;
+      border-radius: 3px;
+    }
+    .markdown-body pre {
+      background-color: var(--vscode-textCodeBlock-background);
+      padding: 12px;
+      border-radius: 4px;
+      overflow-x: auto;
+      margin: 8px 0;
+    }
+    .markdown-body pre code {
+      background: none;
+      padding: 0;
+    }
+    .markdown-body blockquote {
+      border-left: 3px solid var(--vscode-textBlockQuote-border);
+      padding-left: 12px;
+      margin: 8px 0;
+      color: var(--vscode-descriptionForeground);
+    }
+    .markdown-body a {
+      color: var(--vscode-textLink-foreground);
+    }
+    .markdown-body a:hover {
+      color: var(--vscode-textLink-activeForeground);
+    }
+    .markdown-body table {
+      border-collapse: collapse;
+      margin: 8px 0;
+      width: 100%;
+    }
+    .markdown-body th, .markdown-body td {
+      border: 1px solid var(--vscode-panel-border);
+      padding: 6px 10px;
+      text-align: left;
+    }
+    .markdown-body th {
+      background-color: var(--vscode-editor-background);
+      font-weight: 600;
+    }
+    .markdown-body hr {
+      border: none;
+      border-top: 1px solid var(--vscode-panel-border);
+      margin: 16px 0;
+    }
     .labels {
       display: flex;
       gap: 4px;
@@ -352,7 +455,7 @@ function getDetailHtml(issue: BeadsIssue, ancestors: BeadsIssue[], children: Bea
       ? `
   <div class="section">
     <div class="section-title">Description</div>
-    <div class="section-content">${escapeHtml(issue.description)}</div>
+    <div class="section-content markdown-body">${renderMarkdown(issue.description)}</div>
   </div>
   `
       : ''


### PR DESCRIPTION
## Summary

Renders issue descriptions as formatted markdown instead of plain text in the detail webview panel.

**Before:** Raw markdown syntax displayed as-is (code fences, bullet markers, headers with `#`, etc.)
**After:** Descriptions render with proper formatting — headings, code blocks, inline code, lists, tables, blockquotes, and links.

## Implementation

| File | Change |
|------|--------|
| `package.json` | Added `marked` v17 as a runtime dependency |
| `src/extension.ts` | Lazy-initialized `Marked` instance with GFM + breaks; `renderMarkdown()` helper replaces `escapeHtml()` for descriptions; `.markdown-body` CSS using VS Code theme variables |

### Key design choices

- **Server-side rendering**: Markdown is converted to HTML in the extension host (Node.js), not in the webview. Works within the existing CSP.
- **Lazy initialization**: Avoids ESM/CJS issues at module load time. esbuild handles the conversion at bundle time.
- **Graceful fallback**: If `marked` fails to load or parse, falls back to escaped plain text — no breakage.
- **Theme-aware CSS**: All markdown styles use VS Code CSS variables (`--vscode-textCodeBlock-background`, `--vscode-textLink-foreground`, `--vscode-panel-border`, etc.) for native look in any theme.

## Test Plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Biome lint passes (via pre-commit check)
- [ ] Descriptions with code blocks render with syntax formatting
- [ ] Descriptions with lists render as bullet/numbered lists
- [ ] Descriptions with links render as clickable links
- [ ] Plain text descriptions still render correctly
- [ ] Works in both dark and light themes

Closes #49

Made with [Cursor](https://cursor.com)